### PR TITLE
Changed the parameter 'default' to 'default_value'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ You can override the default locale and available locales by including
 the module with this special syntax:
 
     class { locales:
-      default => "nb_NO.UTF-8",
-      available => ["nb_NO.UTF-8 UTF-8", "en_GB.UTF-8 UTF-8"]
+      default_value  => "nb_NO.UTF-8",
+      available      => ["nb_NO.UTF-8 UTF-8", "en_GB.UTF-8 UTF-8"]
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-class locales($default='en_US.UTF-8', $available=['en_US.UTF-8 UTF-8']) {
+class locales($default_value='en_US.UTF-8', $available=['en_US.UTF-8 UTF-8']) {
   package { 'locales':
     ensure => present,
   }
@@ -8,7 +8,7 @@ class locales($default='en_US.UTF-8', $available=['en_US.UTF-8 UTF-8']) {
   }
 
   file { '/etc/default/locale':
-    content => inline_template('LANG=<%= default + "\n" %>'),
+    content => inline_template('LANG=<%= default_value + "\n" %>'),
   }
 
   exec { 'locale-gen':


### PR DESCRIPTION
I tried to use the parameter 'default' in Puppet 2.7.19 but it wouldn't
work. It's use caused a syntax error. So I guess puppet treats 'default'
as some sort of keyword. Hence, I changed the parameter to
'default_value' and it worked out.
