### PR TITLE
Added the full path of the commands 'locale-gen' and 'update-locale'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,16 +11,16 @@ class locales($default='en_US.UTF-8', $available=['en_US.UTF-8 UTF-8']) {
     content => inline_template('LANG=<%= default + "\n" %>'),
   }
 
-  exec { 'locale-gen':
+  exec { '/usr/sbin/locale-gen':
     subscribe   => [File['/etc/locale.gen'], File['/etc/default/locale']],
     refreshonly => true,
   }
 
-  exec { 'update-locale':
+  exec { '/usr/sbin/update-locale':
     subscribe   => [File['/etc/locale.gen'], File['/etc/default/locale']],
     refreshonly => true,
   }
 
   Package[locales] -> File['/etc/locale.gen'] -> File['/etc/default/locale']
-  -> Exec['locale-gen'] -> Exec['update-locale']
+  -> Exec['/usr/sbin/locale-gen'] -> Exec['/usr/sbin/update-locale']
 }


### PR DESCRIPTION
When I tried to use the module on Puppet 2.7.19 on Ubuntu Precise I got:

> 'update-locale' is not qualified and no path was specified. Please
> qualify the command or specify a path.

So I changed the code to use the full path of these commands and it
worked out.
