### PR TITLE
Update template to use instance variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,11 @@ class locales($default_value='en_US.UTF-8', $available=['en_US.UTF-8 UTF-8']) {
   }
 
   file { '/etc/locale.gen':
-    content => inline_template('<%= available.join("\n") + "\n" %>'),
+    content => inline_template('<%= @available.join("\n") + "\n" %>'),
   }
 
   file { '/etc/default/locale':
-    content => inline_template('LANG=<%= default_value + "\n" %>'),
+    content => inline_template('LANG=<%= @default_value + "\n" %>'),
   }
 
   exec { '/usr/sbin/locale-gen':


### PR DESCRIPTION
When running on puppet 3.2.3 need to update variable to remove deprecation notice. Not using instance variables targeted for removal in Puppet 4.

Aug 12 08:21:52 puppet puppet-master[18202]: Variable access via 'available' is deprecated. Use '@available' instead. template[inline]:1
Aug 12 08:21:52 puppet puppet-master[18202]:    (at (erb):1:in `block in result')
