### PR TITLE
Ubuntu xenial behaves like other debian distros

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,12 @@ class locales(
   }
 
   case $::operatingsystem {
-    ubuntu: { $localegenfile = '/var/lib/locales/supported.d/local' }
+    ubuntu: {
+      case $::lsbdistcodename {
+        xenial: { $localegenfile = '/etc/locale.gen' }
+        default: { $localegenfile = '/var/lib/locales/supported.d/local' }
+      }
+    }
     default: { $localegenfile = '/etc/locale.gen' }
   }
 


### PR DESCRIPTION
It seems like newer versions of ubuntu use the same file as debian.