### PR TITLE
[WIP] Replace deprecated stdlib functions with puppet data types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ script: "bundle exec rake validate lint spec SPEC_OPTS='--color --format documen
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
-  - rvm: 2.1.10
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
   - rvm: 2.1.10
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.2.6
@@ -18,8 +14,3 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.4.0
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
-  allow_failures:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
-    - rvm: 2.1.10
-      env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,19 +1,19 @@
 class locales::config inherits locales {
-  file { $::locales::localegenfile:
-    content => inline_template('<%= @available.join("\n") + "\n" %>'),
+  $_available_join = $::locales::available.join("\n")
+
+  file {
+    $::locales::localegenfile:
+      content => "${_available_join}\n";
+    '/etc/default/locale':
+      content => "LANG=${::locales::default_value}\nLC_CTYPE=${::locales::default_value}\nLC_ALL=${::locales::default_value}\n";
   }
 
-  file { '/etc/default/locale':
-    content => template('locales/default_locales.erb')
-  }
-
-  exec { '/usr/sbin/locale-gen':
-    subscribe   => [File[$::locales::localegenfile], File['/etc/default/locale']],
-    refreshonly => true,
-  }
-
-  exec { '/usr/sbin/update-locale':
-    subscribe   => [File[$::locales::localegenfile], File['/etc/default/locale']],
-    refreshonly => true,
+  exec {
+    '/usr/sbin/locale-gen':
+      subscribe   => File[$::locales::localegenfile, '/etc/default/locale'],
+      refreshonly => true;
+    '/usr/sbin/update-locale':
+      subscribe   => File[$::locales::localegenfile, '/etc/default/locale'],
+      refreshonly => true;
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,9 @@ class locales::config inherits locales {
     $::locales::localegenfile:
       content => "${_available_join}\n";
     '/etc/default/locale':
-      content => "LANG=${::locales::default_value}\nLC_CTYPE=${::locales::default_value}\nLC_ALL=${::locales::default_value}\n";
+      content => epp('locales/locale.epp', {
+        'default_value' => $::locales::default_value
+      });
   }
 
   exec {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,9 @@
 class locales (
-  Array[String]                 $available      = $::locales::params::available,
-  String                        $default_value  = $::locales::params::default_value,
-  Stdlib::Compat::Absolute_path $localegenfile  = $::locales::params::localegenfile,
-  String                        $package_ensure = $::locales::params::package_ensure,
-  String                        $package_name   = $::locales::params::package_name,
+  Array[String]        $available      = $::locales::params::available,
+  String               $default_value  = $::locales::params::default_value,
+  Stdlib::Absolutepath $localegenfile  = $::locales::params::localegenfile,
+  String               $package_ensure = $::locales::params::package_ensure,
+  String               $package_name   = $::locales::params::package_name,
 ) inherits locales::params {
 
   anchor { 'locales::begin': }  ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,17 +1,10 @@
 class locales (
-  $available      = $::locales::params::available,
-  $default_value  = $::locales::params::default_value,
-  $localegenfile  = $::locales::params::localegenfile,
-  $package_ensure = $::locales::params::package_ensure,
-  $package_name   = $::locales::params::package_name,
+  Array[String]                 $available      = $::locales::params::available,
+  String                        $default_value  = $::locales::params::default_value,
+  Stdlib::Compat::Absolute_path $localegenfile  = $::locales::params::localegenfile,
+  String                        $package_ensure = $::locales::params::package_ensure,
+  String                        $package_name   = $::locales::params::package_name,
 ) inherits locales::params {
-  validate_array($available)
-  validate_string(
-    $default_value,
-    $package_ensure,
-    $package_name
-  )
-  validate_absolute_path($localegenfile)
 
   anchor { 'locales::begin': }  ->
   class { 'locales::install': }  ->

--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,12 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=2.2.1 <5.0.0" }
+    {"name":"puppetlabs/stdlib","version_requirement":">=4.13.0 <5.0.0" }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">=4.6.1 <5.0.0"
+    }
   ]
 }

--- a/templates/default_locales.erb
+++ b/templates/default_locales.erb
@@ -1,3 +1,0 @@
-LANG=<%= @default_value %>
-LC_CTYPE=<%= @default_value %>
-LC_ALL=<%= @default_value %>

--- a/templates/locale.epp
+++ b/templates/locale.epp
@@ -1,0 +1,4 @@
+<%- | String $default_value | -%>
+LANG=<%= $default_value %>
+LC_CTYPE=<%= $default_value %>
+LC_ALL=<%= $default_value %>


### PR DESCRIPTION
Since you drop the puppet 3 support. You can use puppet data types instead the old deprecated validate functions